### PR TITLE
Introduce `returnif` to babel parser & generator

### DIFF
--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -54,15 +54,25 @@ function getObjectHash(obj) {
   return hash + 2147483647 + 1;
 };
 
-export function OptionReturnStatement(node: Object) {
-  var varName = 'optionReturn_' + getObjectHash(node); // 1) it's deterministic 2) we have it
+export function ReturnIfStatement(node: Object) {
+  /* Creating a named `var` seems unavoidable here. Is there another way?
+   * 
+   * If we name a var:
+   *     1) its name must not collide with others in our program
+   *     2) transipiling should remain deterministic
+   * 
+   * Using the hash of the AST node as variable name suffix (likely) achieves these 2 properites.
+   * This seems both clever and dirty, but it's what I went with.
+   */
+  var varName = 'returnIf_' + getObjectHash(node);
+
   this.word("var");
   this.space();
   this.word(varName);
   this.space();
   this.token("=");
   this.space();
-  this.token("("); // extra parens for good luck
+  this.token("("); // extra parens, for good luck
   this.print(node.argument, node);
   this.token(")");
   this.token(";");

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -41,6 +41,53 @@ export function IfStatement(node: Object) {
   }
 }
 
+// @esmiralha @momo https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript-jquery
+function getObjectHash(obj) {
+  var str = JSON.stringify(obj);
+  var hash = 0, i, chr;
+  if (str.length === 0) return hash;
+  for (i = 0; i < str.length; i++) {
+    chr = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash + 2147483647 + 1;
+};
+
+export function OptionReturnStatement(node: Object) {
+  var varName = 'optionReturn_' + getObjectHash(node); // 1) it's deterministic 2) we have it
+  this.word("var");
+  this.space();
+  this.word(varName);
+  this.space();
+  this.token("=");
+  this.space();
+  this.token("("); // extra parens for good luck
+  this.print(node.argument, node);
+  this.token(")");
+  this.token(";");
+
+  this.newline();
+  this.word("if");
+  this.space();
+  this.token("(");
+  this.word(varName);
+  this.token(")");
+  this.space();
+  this.token("{");
+  this.newline();
+
+  this.indent();
+  this.word("return");
+  this.space();
+  this.word(varName);
+  this.token(";")
+  this.dedent();
+
+  this.newline();
+  this.token("}");
+}
+
 // Recursively get the last statement.
 function getLastStatement(statement) {
   if (!t.isStatement(statement.body)) return statement;

--- a/packages/babel-generator/src/generators/statements.js
+++ b/packages/babel-generator/src/generators/statements.js
@@ -96,6 +96,7 @@ export function ReturnIfStatement(node: Object) {
 
   this.newline();
   this.token("}");
+  this.newline();
 }
 
 // Recursively get the last statement.

--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -145,6 +145,7 @@ export function SequenceExpression(node: Object, parent: Object): boolean {
     t.isForStatement(parent) ||
     t.isThrowStatement(parent) ||
     t.isReturnStatement(parent) ||
+    t.type === "OptionReturnStatement" || // ¯\_(ツ)_/¯
     (t.isIfStatement(parent) && parent.test === node) ||
     (t.isWhileStatement(parent) && parent.test === node) ||
     (t.isForInStatement(parent) && parent.right === node) ||

--- a/packages/babel-generator/src/node/parentheses.js
+++ b/packages/babel-generator/src/node/parentheses.js
@@ -145,7 +145,7 @@ export function SequenceExpression(node: Object, parent: Object): boolean {
     t.isForStatement(parent) ||
     t.isThrowStatement(parent) ||
     t.isReturnStatement(parent) ||
-    t.type === "OptionReturnStatement" || // ¯\_(ツ)_/¯
+    t.type === "ReturnIfStatement" || // keep my changes to 2 packages and ignore @babel/types. this will break other clients ¯\_(ツ)_/¯.
     (t.isIfStatement(parent) && parent.test === node) ||
     (t.isWhileStatement(parent) && parent.test === node) ||
     (t.isForInStatement(parent) && parent.right === node) ||

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -116,6 +116,8 @@ export default class StatementParser extends ExpressionParser {
         return this.parseIfStatement(node);
       case tt._return:
         return this.parseReturnStatement(node);
+      case tt._option_return:
+        return this.parseOptionReturnStatement(node);
       case tt._switch:
         return this.parseSwitchStatement(node);
       case tt._throw:
@@ -478,6 +480,18 @@ export default class StatementParser extends ExpressionParser {
     }
 
     return this.finishNode(node, "ReturnStatement");
+  }
+
+  parseOptionReturnStatement(node: N.OptionReturnStatement): N.OptionReturnStatement {
+    if (!this.state.inFunction && !this.options.allowReturnOutsideFunction) {
+      this.raise(this.state.start, "'return' outside of function");
+    }
+
+    this.next();
+    node.argument = this.parseExpression();
+    this.semicolon();
+
+    return this.finishNode(node, "OptionReturnStatement");
   }
 
   parseSwitchStatement(node: N.SwitchStatement): N.SwitchStatement {

--- a/packages/babel-parser/src/parser/statement.js
+++ b/packages/babel-parser/src/parser/statement.js
@@ -116,8 +116,8 @@ export default class StatementParser extends ExpressionParser {
         return this.parseIfStatement(node);
       case tt._return:
         return this.parseReturnStatement(node);
-      case tt._option_return:
-        return this.parseOptionReturnStatement(node);
+      case tt._returnif:
+        return this.parseReturnIfStatement(node);
       case tt._switch:
         return this.parseSwitchStatement(node);
       case tt._throw:
@@ -482,7 +482,7 @@ export default class StatementParser extends ExpressionParser {
     return this.finishNode(node, "ReturnStatement");
   }
 
-  parseOptionReturnStatement(node: N.OptionReturnStatement): N.OptionReturnStatement {
+  parseReturnIfStatement(node: N.ReturnIfStatement): N.ReturnIfStatement {
     if (!this.state.inFunction && !this.options.allowReturnOutsideFunction) {
       this.raise(this.state.start, "'return' outside of function");
     }
@@ -491,7 +491,7 @@ export default class StatementParser extends ExpressionParser {
     node.argument = this.parseExpression();
     this.semicolon();
 
-    return this.finishNode(node, "OptionReturnStatement");
+    return this.finishNode(node, "ReturnIfStatement");
   }
 
   parseSwitchStatement(node: N.SwitchStatement): N.SwitchStatement {

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1360,7 +1360,7 @@ export default class Tokenizer extends LocationParser {
       }
     }
 
-    if (prevType === tt._return) {
+  if (prevType === tt._return || prevType === tt._option_return) {
       return lineBreak.test(
         this.input.slice(this.state.lastTokEnd, this.state.start),
       );

--- a/packages/babel-parser/src/tokenizer/index.js
+++ b/packages/babel-parser/src/tokenizer/index.js
@@ -1360,7 +1360,7 @@ export default class Tokenizer extends LocationParser {
       }
     }
 
-  if (prevType === tt._return || prevType === tt._option_return) {
+  if (prevType === tt._return || prevType === tt._returnif) {
       return lineBreak.test(
         this.input.slice(this.state.lastTokEnd, this.state.start),
       );

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -169,6 +169,7 @@ export const keywords = {
   function: new KeywordTokenType("function", { startsExpr }),
   if: new KeywordTokenType("if"),
   return: new KeywordTokenType("return", { beforeExpr }),
+  option_return: new KeywordTokenType("option_return", { beforeExpr }),
   switch: new KeywordTokenType("switch"),
   throw: new KeywordTokenType("throw", { beforeExpr, prefix, startsExpr }),
   try: new KeywordTokenType("try"),

--- a/packages/babel-parser/src/tokenizer/types.js
+++ b/packages/babel-parser/src/tokenizer/types.js
@@ -169,7 +169,7 @@ export const keywords = {
   function: new KeywordTokenType("function", { startsExpr }),
   if: new KeywordTokenType("if"),
   return: new KeywordTokenType("return", { beforeExpr }),
-  option_return: new KeywordTokenType("option_return", { beforeExpr }),
+  returnif: new KeywordTokenType("returnif", { beforeExpr }),
   switch: new KeywordTokenType("switch"),
   throw: new KeywordTokenType("throw", { beforeExpr, prefix, startsExpr }),
   try: new KeywordTokenType("try"),

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -207,6 +207,11 @@ export type ReturnStatement = NodeBase & {
   argument: ?Expression,
 };
 
+export type OptionReturnStatement = NodeBase & {
+  type: "OptionReturnStatement",
+  argument: ?Expression,
+};
+
 export type LabeledStatement = NodeBase & {
   type: "LabeledStatement",
   label: Identifier,

--- a/packages/babel-parser/src/types.js
+++ b/packages/babel-parser/src/types.js
@@ -207,8 +207,8 @@ export type ReturnStatement = NodeBase & {
   argument: ?Expression,
 };
 
-export type OptionReturnStatement = NodeBase & {
-  type: "OptionReturnStatement",
+export type ReturnIfStatement = NodeBase & {
+  type: "ReturnIfStatement",
   argument: ?Expression,
 };
 

--- a/packages/babel-parser/src/util/identifier.js
+++ b/packages/babel-parser/src/util/identifier.js
@@ -24,7 +24,7 @@ export const reservedWords = {
 // And the keywords
 
 export const isKeyword = makePredicate(
-  "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this let const class extends export import yield super",
+  "break case catch continue debugger default do else finally for function if option_return return switch throw try var while with null true false instanceof typeof void delete new in this let const class extends export import yield super",
 );
 
 // ## Character categories

--- a/packages/babel-parser/src/util/identifier.js
+++ b/packages/babel-parser/src/util/identifier.js
@@ -24,7 +24,7 @@ export const reservedWords = {
 // And the keywords
 
 export const isKeyword = makePredicate(
-  "break case catch continue debugger default do else finally for function if option_return return switch throw try var while with null true false instanceof typeof void delete new in this let const class extends export import yield super",
+  "break case catch continue debugger default do else finally for function if returnif return switch throw try var while with null true false instanceof typeof void delete new in this let const class extends export import yield super",
 );
 
 // ## Character categories


### PR DESCRIPTION
Check out the full post here: https://suczewski.com/2018/07/returnif

`returnif` allows one to conditionally return from a function based on 1) the truthiness of the value to be returned or 2) a precondition. Here I've done part 1. To do this I:

- I added a few lines to interpret `returnif` similar to `return`. Their declarations and representations in the AST are the same for case 1.

- Use hash of the AST node as the suffix for a temp variable name to generate plain js